### PR TITLE
Fix gallery images on services page

### DIFF
--- a/leistungen.html
+++ b/leistungen.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>NDN Sanierung – Leistungen</title>
-  <link rel="icon" href="/assets/logo.png">
-  <link rel="stylesheet" href="/styles.css">
+  <link rel="icon" href="/src/assets/logo.png">
+  <link rel="stylesheet" href="/src/styles.css">
   <script>
     (function(){
       try {
@@ -23,7 +23,7 @@
 <header class="app-header">
   <div class="container navbar">
     <a href="/index.html" class="logo">
-      <img class="logo-img" src="/assets/logo.png" alt="NDN Logo">
+      <img class="logo-img" src="/src/assets/logo.png" alt="NDN Logo">
       <div class="logo-text">NDN Sanierung</div>
     </a>
     <nav class="desktop-nav">
@@ -56,9 +56,9 @@
         <hr class="red-line">
       </div>
       <div class="carousel" id="asbestCarousel" aria-label="Asbest Galerie">
-        <img src="/assets/cons1.jpg" alt="Asbestarbeit 1">
-        <img src="/assets/cons2.jpg" alt="Asbestarbeit 2">
-        <img src="/assets/cons4.jpg" alt="Asbestarbeit 3">
+        <img src="/src/assets/cons1.jpg" alt="Asbestarbeit 1">
+        <img src="/src/assets/cons2.jpg" alt="Asbestarbeit 2">
+        <img src="/src/assets/cons4.jpg" alt="Asbestarbeit 3">
       </div>
     </div>
 
@@ -125,6 +125,6 @@
   <div class="container rights" data-i18n="footer.rights">© 2025 NDN Sanierung. Alle Rechte vorbehalten.</div>
 </footer>
 
-<script src="/js/main.js"></script>
+<script src="/src/js/main.js"></script>
 </body>
 </html>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -254,10 +254,9 @@
       if (!carousel) return;
 
       const images = [
-        '/src/assets/asbest1.png',
-        '/src/assets/asbest2.png',
-        '/src/assets/asbest3.png',
-        '/src/assets/asbest4.png',
+        '/src/assets/cons1.jpg',
+        '/src/assets/cons2.jpg',
+        '/src/assets/cons4.jpg',
       ];
 
       let idx = 0;


### PR DESCRIPTION
## Summary
- Correct asset paths in `leistungen.html` so styles, logo, and gallery images load from `src`
- Update gallery initialization in `main.js` to display `cons1.jpg`, `cons2.jpg`, and `cons4.jpg`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a44a0277588321a2c660cc45c883a7