### PR TITLE
Add red underline beneath home page card titles

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -59,9 +59,9 @@
   </div>
 </section>
 <section class="container features">
-  <div class="card"><h3>TRGS 519</h3><p data-i18n="home.point1">Asbestos remediation according to TRGS 519. We handle planning, execution and disposal.</p></div>
-  <div class="card"><h3 data-i18n="home.point2_title">Quick on Site</h3><p data-i18n="home.point2">Flexible scheduling. Our team is ready at short notice.</p></div>
-  <div class="card"><h3 data-i18n="home.point3_title">Experience</h3><p data-i18n="home.point3">Qualified specialists. Benefit from years of hands-on experience.</p></div>
+  <div class="card"><h3>TRGS 519</h3><hr class="red-line"><p data-i18n="home.point1">Asbestos remediation according to TRGS 519. We handle planning, execution and disposal.</p></div>
+  <div class="card"><h3 data-i18n="home.point2_title">Quick on Site</h3><hr class="red-line"><p data-i18n="home.point2">Flexible scheduling. Our team is ready at short notice.</p></div>
+  <div class="card"><h3 data-i18n="home.point3_title">Experience</h3><hr class="red-line"><p data-i18n="home.point3">Qualified specialists. Benefit from years of hands-on experience.</p></div>
 </section>
 
 

--- a/index.html
+++ b/index.html
@@ -58,9 +58,9 @@
   </div>
 </section>
 <section class="container features">
-  <div class="card"><h3>TRGS 519</h3><p data-i18n="home.point1">Asbestsanierung gemäß TRGS 519. Wir kümmern uns um Planung, Durchführung und Entsorgung.</p></div>
-  <div class="card"><h3 data-i18n="home.point2_title">Schnell vor Ort</h3><p data-i18n="home.point2">Flexible Terminvereinbarung. Unser Team ist kurzfristig einsatzbereit.</p></div>
-  <div class="card"><h3 data-i18n="home.point3_title">Erfahrung</h3><p data-i18n="home.point3">Qualifiziertes Fachpersonal. Profitieren Sie von jahrelanger Erfahrung.</p></div>
+  <div class="card"><h3>TRGS 519</h3><hr class="red-line"><p data-i18n="home.point1">Asbestsanierung gemäß TRGS 519. Wir kümmern uns um Planung, Durchführung und Entsorgung.</p></div>
+  <div class="card"><h3 data-i18n="home.point2_title">Schnell vor Ort</h3><hr class="red-line"><p data-i18n="home.point2">Flexible Terminvereinbarung. Unser Team ist kurzfristig einsatzbereit.</p></div>
+  <div class="card"><h3 data-i18n="home.point3_title">Erfahrung</h3><hr class="red-line"><p data-i18n="home.point3">Qualifiziertes Fachpersonal. Profitieren Sie von jahrelanger Erfahrung.</p></div>
 </section>
 
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -182,6 +182,7 @@ html.light .cookie-banner {
 .content-header { margin: 32px 0 12px; text-align: left; }
 .content-header h1, .content-header h2 { margin: 0 0 8px; }
 .red-line { height: 4px; background: var(--accent); border: none; width: 80px; border-radius: 2px; }
+.card .red-line { align-self: center; }
 .center-page .content-header { text-align: center; }
 .content-header.services-header h1 { font-size: 2.4rem; }
 


### PR DESCRIPTION
## Summary
- Add red accent line under each feature card heading on home pages
- Center card accent line via CSS

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a882b6949483218e898dce7b0daa8b