### PR TITLE
Remove images from services page

### DIFF
--- a/leistungen.html
+++ b/leistungen.html
@@ -6,8 +6,6 @@
   <title>NDN Sanierung – Leistungen</title>
   <link rel="icon" href="src/assets/images/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="src/styles.css">
-  <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/featherlight@1.7.14/release/featherlight.min.css">
   <script>
     (function(){
       try {
@@ -83,34 +81,6 @@
         Wir sanieren weitere Schadstoffe wie KMF, PCB, PAK und Holzschutzmittel – ganzheitlich und sicher.
       </p>
     </div>
-    <!-- IMAGE SLIDER -->
-    <section class="section-wrap fullwidth ohide">
-      <div class="content-header">
-        <h2 data-i18n="leistungen.gallery_title">Einblicke in unsere Arbeit – Asbest</h2>
-        <hr class="red-line">
-      </div>
-      <div class="image-gallery-slider swiper">
-        <div class="swiper-wrapper">
-          <div class="swiper-slide">
-            <a href="src/assets/images/cons1.jpg" data-featherlight="image">
-              <img src="src/assets/images/cons1.jpg" alt="Asbest Galerie Bild 1">
-            </a>
-          </div>
-          <div class="swiper-slide">
-            <a href="src/assets/images/cons2.jpg" data-featherlight="image">
-              <img src="src/assets/images/cons2.jpg" alt="Asbest Galerie Bild 2">
-            </a>
-          </div>
-          <div class="swiper-slide">
-            <a href="src/assets/images/cons4.jpg" data-featherlight="image">
-              <img src="src/assets/images/cons4.jpg" alt="Asbest Galerie Bild 3">
-            </a>
-          </div>
-        </div>
-        <div class="swiper-button-prev"></div>
-        <div class="swiper-button-next"></div>
-      </div>
-    </section>
 
   </section>
 </main>
@@ -142,8 +112,6 @@
   <div class="container rights" data-i18n="footer.rights">© 2025 NDN Sanierung. Alle Rechte vorbehalten.</div>
 </footer>
 
-<script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/featherlight@1.7.14/release/featherlight.min.js"></script>
 <script src="src/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- delete image gallery slider from services page
- drop Swiper and Featherlight dependencies that powered the gallery

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa3e752888321a62f01bbc03a595e